### PR TITLE
Adding event to subscribe type message from Redis

### DIFF
--- a/flask_sse.py
+++ b/flask_sse.py
@@ -139,6 +139,8 @@ class ServerSentEventsBlueprint(Blueprint):
             if pubsub_message['type'] == 'message':
                 msg_dict = json.loads(pubsub_message['data'])
                 yield Message(**msg_dict)
+            elif pubsub_message['type'] == 'subscribe':
+                yield Message('Connected', type='connected')
 
     def stream(self):
         """


### PR DESCRIPTION
When the user connect on Redis using `EventSource` from javascript, the server doesn't sent an ack verification to the cliente so the open event from `EventSource` isn't triggered.